### PR TITLE
Reworked ocr script to use grimblast and - as input and outputs

### DIFF
--- a/scripts/ocr.sh
+++ b/scripts/ocr.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
 
-# Optional slurp arguments
-SLURP_ARGS="${1:-}"
+# Take a screenshot and perform OCR
+ocr_text=$(grimblast --freeze save area - | tesseract -l eng - - 2>/dev/null)
 
-# Temporary file name
-TMP_IMG="tmp.png"
-
-# Select area with slurp and capture with grim
-grim -g "$(slurp $SLURP_ARGS)" "$TMP_IMG" && \
-tesseract -l eng "$TMP_IMG" - | wl-copy && \
-
-
-if [ -f "${TMP_IMG}" ]; then
-    notify-send -a "Ax-Shell" -i "${full_path}" "OCR Sucess" "Text Copied to Clipboard"
+# Check if OCR was successful
+if [[ -n "$ocr_text" ]]; then
+    echo -n "$ocr_text" | wl-copy
+    notify-send -a "Ax-Shell" "OCR Success" "Text Copied to Clipboard"
 else
-    notify-send -a "Ax-Shell" "OCR Aborted"
+    notify-send -a "Ax-Shell" "OCR Failed" "No text recognized or operation failed"
 fi
-rm "$TMP_IMG"


### PR DESCRIPTION
Removes the need for a tmp file (and the dependency on slurp and grim).
Should be no problem since grimblast is already a dependency and can do it without slurp.

(the --freeze is a personal preference, if you don't like it, it can be removed again)