### PR TITLE
Fix kanban inline editor behavior

### DIFF
--- a/modules/kanban.py
+++ b/modules/kanban.py
@@ -135,10 +135,9 @@ class KanbanNote(Gtk.EventBox):
         self.connect("drag-begin", self.on_drag_begin)
 
     def on_button_press(self, widget, event):
-        # If it's a double-click, start editing.
-        if event.type == Gdk.EventType._2BUTTON_PRESS:
-            self.start_edit()
+        if event.type != Gdk.EventType._2BUTTON_PRESS:
             return True
+        self.start_edit()
         return False
 
     def on_drag_begin(self, widget, context):


### PR DESCRIPTION
Some unexpected behavior in `KanbanNote.on_button_press`, where calling `start_edit()` within the conditional messes up the editor grabbing focus. Tried an early return if the event isn't a 2 button press, otherwise adding the editor, and it works as expected now.