### PR TITLE
Fixed clipboard manager UTF-8 encoding

### DIFF
--- a/modules/cliphist.py
+++ b/modules/cliphist.py
@@ -116,10 +116,11 @@ class ClipHistory(Box):
             result = subprocess.run(
                 ["cliphist", "list"], 
                 capture_output=True, 
-                text=True, 
                 check=True
             )
-            lines = result.stdout.strip().split('\n')
+            # Decode stdout with error handling
+            stdout_str = result.stdout.decode('utf-8', errors='replace')
+            lines = stdout_str.strip().split('\n')
             new_items = []
             for line in lines:
                 if not line or "<meta http-equiv" in line:


### PR DESCRIPTION
I got an error when using the in Ax-Shell built in clipboard manager (Unexpected error: 'utf-8' codec can't decode byte 0xe2 in position 4194: invalid continuation byte) so i fixed it.