### PR TITLE
Fix tabler icons not working when installed with install.sh script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e  # Exit immediately if a command fails
 set -u  # Treat unset variables as errors
 set -o pipefail  # Prevent errors in a pipeline from being masked
 
-REPO_URL="https://github.com/Axenide/Ax-Shell.git"
+# REPO_URL="https://github.com/Axenide/Ax-Shell.git"
 INSTALL_DIR="$HOME/.config/Ax-Shell"
 PACKAGES=(
   brightnessctl
@@ -112,7 +112,7 @@ fi
 if [ ! -d "$HOME/.fonts/tabler-icons" ]; then
     echo "Copying local fonts to $HOME/.fonts/tabler-icons..."
     mkdir -p "$HOME/.fonts/tabler-icons"
-    cp -r "$INSTALL_DIR/assets/fonts/"* "$HOME/.fonts/tabler-icons"
+    cp -r "$INSTALL_DIR/assets/fonts/"* "$HOME/.fonts"
 else
     echo "Local fonts are already installed. Skipping copy."
 fi

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e  # Exit immediately if a command fails
 set -u  # Treat unset variables as errors
 set -o pipefail  # Prevent errors in a pipeline from being masked
 
-# REPO_URL="https://github.com/Axenide/Ax-Shell.git"
+REPO_URL="https://github.com/Axenide/Ax-Shell.git"
 INSTALL_DIR="$HOME/.config/Ax-Shell"
 PACKAGES=(
   brightnessctl


### PR DESCRIPTION
By default the install.sh script installs the tabler-icons.ttf font file to a nested directory ($HOME/.fonts/tabler-icons/tabler-icons) this causes the ax-shell unable to properly find and use the tabler-icons, this is a simple one line fix that just removes the nesting of directory to properly install the icons. 