### PR TITLE
[Feature] Close dashbroard clicking beyond

### DIFF
--- a/modules/notch.py
+++ b/modules/notch.py
@@ -133,6 +133,13 @@ class Notch(Window):
             all_visible=True,
         )
 
+        # 1. Add event mask for button press to the window
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
+        # 2. Connect to the window's button-press-event
+        self.connect("button-press-event", self._on_window_button_press)
+        # 3. Connect to focus-out-event
+        self.connect("focus-out-event", self._on_focus_out)
+
         self._typed_chars_buffer = ""
         self._launcher_transitioning = False
         self._launcher_transition_timeout = None
@@ -464,12 +471,30 @@ class Notch(Window):
         if data.PANEL_THEME != "Notch":
             self.notch_revealer.set_reveal_child(False)
 
-    def open_notch(self, widget_name: str):
+        if data.PANEL_THEME == "Notch":
+            seat = Gdk.Display.get_default().get_default_seat()
+            seat.ungrab()
+
+    def open_notch(self, widget_name: str, *args, **kwargs):
         self.notch_revealer.set_reveal_child(True)
         self.notch_box.add_style_class("open")
         self.stack.add_style_class("open")
         current_stack_child = self.stack.get_visible_child()
-        is_dashboard_currently_visible = (current_stack_child == self.dashboard)
+        is_dashboard_currently_visible = current_stack_child == self.dashboard
+
+        if data.PANEL_THEME == "Notch":
+            seat = Gdk.Display.get_default().get_default_seat()
+            if self.get_window() is None:
+                self.realize()
+
+            seat.grab(
+                self.get_window(),
+                Gdk.SeatCapabilities.POINTER,
+                True,
+                None,
+                None,
+                Gdk.Event,
+            )
 
         if widget_name == "network_applet":
             if is_dashboard_currently_visible:

--- a/modules/notch.py
+++ b/modules/notch.py
@@ -457,7 +457,6 @@ class Notch(Window):
         )
 
         if not (is_inside_x and is_inside_y):
-            print("Clicked outside Notch window!") 
             self.close_notch()
             return True  # Event handled, stop propagation
 
@@ -470,7 +469,6 @@ class Notch(Window):
         If it's open and loses focus, close it.
         """
         if self._is_notch_open:
-            print("Notch lost focus, closing.")
             self.close_notch()
             return True
         return False
@@ -526,10 +524,6 @@ class Notch(Window):
             seat = Gdk.Display.get_default().get_default_seat()
             seat.ungrab()
 
-        if data.PANEL_THEME == "Notch":
-            seat = Gdk.Display.get_default().get_default_seat()
-            seat.ungrab()
-
     def open_notch(self, widget_name: str, *args, **kwargs):
         self.notch_revealer.set_reveal_child(True)
         self.notch_box.add_style_class("open")
@@ -542,14 +536,7 @@ class Notch(Window):
             if self.get_window() is None:
                 self.realize()
 
-            seat.grab(
-                self.get_window(),
-                Gdk.SeatCapabilities.POINTER,
-                True,
-                None,
-                None,
-                Gdk.Event,
-            )
+            seat.grab(self.get_window(), Gdk.SeatCapabilities.POINTER, True, None, None, Gdk.Event)
 
         if data.PANEL_THEME == "Notch":
             seat = Gdk.Display.get_default().get_default_seat()

--- a/modules/notch.py
+++ b/modules/notch.py
@@ -981,7 +981,7 @@ class Notch(Window):
             
             if is_valid_char and keychar:
 
-             d   self._typed_chars_buffer += keychar
+                self._typed_chars_buffer += keychar
                 print(f"Buffered character: {keychar}, buffer now: '{self._typed_chars_buffer}'")
                 return True
         

--- a/modules/notch.py
+++ b/modules/notch.py
@@ -133,13 +133,6 @@ class Notch(Window):
             all_visible=True,
         )
 
-        # 1. Add event mask for button press to the window
-        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
-        # 2. Connect to the window's button-press-event
-        self.connect("button-press-event", self._on_window_button_press)
-        # 3. Connect to focus-out-event
-        self.connect("focus-out-event", self._on_focus_out)
-
         self._typed_chars_buffer = ""
         self._launcher_transitioning = False
         self._launcher_transition_timeout = None
@@ -200,6 +193,10 @@ class Notch(Window):
             center_children=self.active_window,
             end_children=None
         )
+        # For the active window box, we want to ensure that the label is ellipsized
+        self.add_events(Gdk.EventMask.BUTTON_PRESS_MASK)
+        self.connect("button-press-event", self._on_window_button_press)
+        self.connect("focus-out-event", self._on_focus_out)
 
         self.active_window_box.connect("button-press-event", lambda widget, event: (self.open_notch("dashboard"), False)[1])
 
@@ -422,6 +419,54 @@ class Notch(Window):
         
 
         self.connect("key-press-event", self.on_key_press)
+    
+    def _on_window_button_press(self, widget, event):
+        """
+        Handler for button press events on the Notch window.
+        Used to detect clicks outside the window when a grab is active.
+        """
+        if event.button != Gdk.BUTTON_PRIMARY:
+            return False
+
+        gdk_window = self.get_window()
+        if not gdk_window:
+            return False
+
+        raw_origin = gdk_window.get_origin()
+        window_x = raw_origin[0]
+        window_y = raw_origin[1]
+
+        window_width = gdk_window.get_width()
+        window_height = gdk_window.get_height()
+
+        click_x_global = event.x_root
+        click_y_global = event.y_root
+
+        is_inside_x = (click_x_global >= window_x) and (
+            click_x_global <= window_x + window_width
+        )
+        is_inside_y = (click_y_global >= window_y) and (
+            click_y_global <= window_y + window_height
+        )
+
+        if not (is_inside_x and is_inside_y):
+            print("Clicked outside Notch window!") 
+            self.close_notch()
+            return True  # Event handled, stop propagation
+
+        # If click was inside, let it propagate so internal widgets can handle it (e.g., dashboard buttons)
+        return False
+
+    def _on_focus_out(self, widget, event):
+        """
+        Handler for when the Notch window loses focus.
+        If it's open and loses focus, close it.
+        """
+        if self._is_notch_open:
+            print("Notch lost focus, closing.")
+            self.close_notch()
+            return True
+        return False
 
     def on_button_enter(self, widget, event):
         self.is_hovered = True
@@ -470,32 +515,24 @@ class Notch(Window):
         self.stack.set_visible_child(self.compact)
         if data.PANEL_THEME != "Notch":
             self.notch_revealer.set_reveal_child(False)
-
         if data.PANEL_THEME == "Notch":
             seat = Gdk.Display.get_default().get_default_seat()
             seat.ungrab()
 
-    def open_notch(self, widget_name: str, *args, **kwargs):
+    def open_notch(self, widget_name: str):
         self.notch_revealer.set_reveal_child(True)
         self.notch_box.add_style_class("open")
         self.stack.add_style_class("open")
         current_stack_child = self.stack.get_visible_child()
-        is_dashboard_currently_visible = current_stack_child == self.dashboard
+        is_dashboard_currently_visible = (current_stack_child == self.dashboard)
 
         if data.PANEL_THEME == "Notch":
             seat = Gdk.Display.get_default().get_default_seat()
             if self.get_window() is None:
                 self.realize()
 
-            seat.grab(
-                self.get_window(),
-                Gdk.SeatCapabilities.POINTER,
-                True,
-                None,
-                None,
-                Gdk.Event,
-            )
-
+            seat.grab(self.get_window(), Gdk.SeatCapabilities.POINTER, True, None, None, Gdk.Event)
+    
         if widget_name == "network_applet":
             if is_dashboard_currently_visible:
 
@@ -805,7 +842,6 @@ class Notch(Window):
 
             self._current_window_class = new_window_class
             
-
             if self._occlusion_timer_id is not None:
                 GLib.source_remove(self._occlusion_timer_id)
                 self._occlusion_timer_id = None

--- a/modules/notch.py
+++ b/modules/notch.py
@@ -981,7 +981,7 @@ class Notch(Window):
             
             if is_valid_char and keychar:
 
-                self._typed_chars_buffer += keychar
+             d   self._typed_chars_buffer += keychar
                 print(f"Buffered character: {keychar}, buffer now: '{self._typed_chars_buffer}'")
                 return True
         


### PR DESCRIPTION
Adds functionality to allow the Notch window to close when the user clicks outside of it.