### PR TITLE
Cohesive active state bgcolor for bluetooth and wifi connected state

### DIFF
--- a/styles/applets.css
+++ b/styles/applets.css
@@ -63,7 +63,7 @@
 }
 
 #wifi-connect-button.connected {
-  background-color: var(--green);
+  background-color: var(--primary);
 }
 
 #wifi-connect-button.connected label {
@@ -71,7 +71,7 @@
 }
 
 #bluetooth-connect.connected {
-  background-color: var(--blue);
+  background-color: var(--primary);
 }
 
 #bluetooth-connect.connected label {
@@ -112,15 +112,15 @@
 
 @keyframes blink {
   0% {
-    background-color: var(--blue);
+    background-color: var(--secondary);
     color: var(--shadow);
   }
   50% {
     background-color: var(--shadow);
-    color: var(--blue);
+    color: var(--secondary);
   }
   100% {
-    background-color: var(--blue);
+    background-color: var(--secondary);
     color: var(--shadow);
   }
 }


### PR DESCRIPTION
![before](https://github.com/user-attachments/assets/74ac4d59-8d3f-46dc-a272-68ccadf5f97f)
before
![after](https://github.com/user-attachments/assets/81234197-fef1-48b8-802a-798b70b00c1f)
after

Used var(--primary)