### PR TITLE
Update screenshot.sh

### DIFF
--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -31,7 +31,7 @@ case $1 in
         hyprshot -z -s -m region -o "$save_dir" -f "$save_file"
         ;;
     w)
-        hyprshot -s -m window -o "$save_dir" -f "$save_file";
+        hyprshot -s -m window -o "$save_dir" -f "$save_file"
         ;;
     *)
         print_error


### PR DESCRIPTION
Fixed issue where 'Screenshot Aborted' message was displayed when taking a window screenshot due to a semicolon at the end of the command.