### PR TITLE
basic support for custom workspace icons

### DIFF
--- a/config/data.py
+++ b/config/data.py
@@ -75,6 +75,7 @@ if os.path.exists(CONFIG_FILE):
         "bar_workspace_use_chinese_numerals", False
     )
     BAR_HIDE_SPECIAL_WORKSPACE = config.get("bar_hide_special_workspace", True)
+    BAR_WORKSPACE_ICONS = config.get("bar_workspace_icons", {})
     BAR_THEME = config.get("bar_theme", "Pills")
     DOCK_THEME = config.get("dock_theme", "Pills")
     PANEL_THEME = config.get("panel_theme", "Pills")

--- a/modules/bar.py
+++ b/modules/bar.py
@@ -45,6 +45,20 @@ tooltip_tools = """<b>Toolbox</b>"""
 tooltip_overview = """<b>Overview</b>"""
 
 
+def build_caption(i: int):
+    """Build the label for a given workspace number"""
+    label = data.BAR_WORKSPACE_ICONS.get(str(i)) or data.BAR_WORKSPACE_ICONS.get('default')
+    if label is None:
+        return (
+            CHINESE_NUMERALS[i - 1]
+            if data.BAR_WORKSPACE_USE_CHINESE_NUMERALS
+            and 1 <= i <= len(CHINESE_NUMERALS)
+            else str(i)
+        )
+    else:
+        return label
+
+
 class Bar(Window):
     def __init__(self, **kwargs):
         super().__init__(
@@ -135,12 +149,7 @@ class Bar(Window):
                     h_align="center",
                     v_align="center",
                     id=i,
-                    label=(
-                        CHINESE_NUMERALS[i - 1]
-                        if data.BAR_WORKSPACE_USE_CHINESE_NUMERALS
-                        and 1 <= i <= len(CHINESE_NUMERALS)
-                        else str(i)
-                    ),
+                    label=build_caption(i),
                 )
                 for i in range(1, 11)
             ],
@@ -155,7 +164,7 @@ class Bar(Window):
             name="workspaces-container",
             children=(
                 self.workspaces
-                if not data.BAR_WORKSPACE_SHOW_NUMBER
+                if not (data.BAR_WORKSPACE_SHOW_NUMBER or data.BAR_WORKSPACE_ICONS)
                 else self.workspaces_num
             ),
         )
@@ -603,7 +612,7 @@ class Bar(Window):
             self.bar_inner.remove_style_class("hidden")
 
     def chinese_numbers(self):
-        if data.BAR_WORKSPACE_USE_CHINESE_NUMERALS:
+        if data.BAR_WORKSPACE_USE_CHINESE_NUMERALS or data.BAR_WORKSPACE_ICONS:
             self.workspaces_num.add_style_class("chinese")
         else:
             self.workspaces_num.remove_style_class("chinese")


### PR DESCRIPTION
This adds support for custom icons.

Since the settings gui for it is more complicated I left it for later.

Example usage (some of those icons don't look perfectly centered):

```json
    "bar_workspace_icons": {
        "1": "",
        "2": "",
        "3": "",
        "4": "燎",
        "5": "蓼",
        "6" : "",
        "7" : "更",
        "8" : "󰭹",
        "9" : "亮",
        "10": "👽",
        "default": ""
    },
```