### PR TITLE
allow to close the notch with a right click on the menu

### DIFF
--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -81,6 +81,11 @@ class Dashboard(Box):
         ):
             GLib.idle_add(self._setup_switcher_icons)
 
+        # Close on right click if the event isn't handled
+        self.connect(
+            "button-release-event",
+            lambda widget, event: (event.button == 3 and self.notch.close_notch()),
+        )
         self.show_all()
 
     def _setup_switcher_icons(self):


### PR DESCRIPTION
I couldn't find  a way to close the compact notch when using  the mouse, this allows to close it on right click if not handled somewhere else...