### PR TITLE
When multiple monitors are used, the OVERVIEW size is fixed relative …

### DIFF
--- a/modules/overview.py
+++ b/modules/overview.py
@@ -22,8 +22,10 @@ gi.require_version("Gtk", "3.0")
 from gi.repository import Gdk, Gtk
 
 screen = Gdk.Screen.get_default()
-CURRENT_WIDTH = screen.get_width()
-CURRENT_HEIGHT = screen.get_height()
+primary = screen.get_primary_monitor()
+geometry = screen.get_monitor_geometry(primary)      # Return Gdk.Rectangle
+CURRENT_WIDTH = geometry.width
+CURRENT_HEIGHT = geometry.height
 
 icon_resolver = IconResolver()
 connection = Hyprland()


### PR DESCRIPTION
## Problem
When using a multi-monitor setup, the overview size scales according to the second monitor.  
The expected behavior is to keep it fixed relative to the **primary monitor** only.

## Solution
I modified the code so that the overview size is now fixed to the primary monitor.

## Notes
Tested on Arch Linux + Hyprland.  
No regressions observed.


https://github.com/user-attachments/assets/be72b9b0-076c-4f49-bca5-7ed9398d7d43

