### PR TITLE
fix: Fixed the icon display of some application trays

### DIFF
--- a/modules/systemtray.py
+++ b/modules/systemtray.py
@@ -2,6 +2,7 @@ import gi
 
 gi.require_version("Gray", "0.1")
 import logging
+import os
 
 from fabric.widgets.box import Box
 from gi.repository import Gdk, GdkPixbuf, GLib, Gray, Gtk
@@ -47,6 +48,18 @@ class SystemTray(Box):
                 return pm.as_pixbuf(self.pixel_size, GdkPixbuf.InterpType.HYPER)
 
             name = item.get_icon_name()
+            # If IconName is a file path, prioritize loading directly from the file
+            if name and os.path.exists(name):
+                try:
+                    return GdkPixbuf.Pixbuf.new_from_file_at_scale(
+                        name, self.pixel_size, self.pixel_size, True
+                    )
+                except Exception as e:
+                    # The file path exists but loading fails, falling back to theme search
+                    logger.debug(
+                        f"Load icon from file failed: {e}; fallback to theme for '{name}'"
+                    )
+
             theme = Gtk.IconTheme.new()
             path = item.get_icon_theme_path()
             if path:


### PR DESCRIPTION
Some applications cannot display icons correctly in the tray (flclash, clash-verge-rev, pot...) because their IconName is actually a file path. A new check is added in _get_item_pixbuf. If IconName is a path, the file with that path will be used as the tray icon.


<img width="212" height="59" alt="图片" src="https://github.com/user-attachments/assets/5eb83c87-3611-44de-bd09-dd1ee0cdc268" />

<img width="253" height="62" alt="图片" src="https://github.com/user-attachments/assets/fc3cc19e-1605-4154-8eb4-89f1111d18d8" />


```
  SNI: tao application  (Category=ApplicationStatus, Status=Active)
  service=:1.239  path=/org/ayatana/NotificationItem/tao_application
  IconName=/run/user/1000/tao/tray-icon-5c98b23d-b2cd-4e23-8f51-3186f615eadc.png  AttentionIconName=
  ItemIsMenu=False  Menu=/org/ayatana/NotificationItem/tao_application/Menu
  Title=pot
-
  SNI: I4e6yb24BC  (Category=ApplicationStatus, Status=Active)
  service=:1.12  path=/org/ayatana/NotificationItem/I4e6yb24BC
  IconName=/usr/lib/flclash/data/flutter_assets/assets/images/icon.png  AttentionIconName=
  ItemIsMenu=False  Menu=/org/ayatana/NotificationItem/I4e6yb24BC/Menu
  Title=com.follow.clash
```