### PR TITLE
Prevent excessive calls to update_dock

### DIFF
--- a/modules/dock.py
+++ b/modules/dock.py
@@ -292,9 +292,6 @@ class Dock(Window):
             self.conn.connect("event::ready", self.update_dock)
             if not self.integrated_mode: self.conn.connect("event::ready", lambda *args: GLib.timeout_add(250, self.check_occlusion_state))
 
-        for ev in ("activewindow", "openwindow", "closewindow", "changefloatingmode"):
-            self.conn.connect(f"event::{ev}", self.update_dock)
-        
         if not self.integrated_mode:
             self.conn.connect("event::workspace", self.check_hide)
         


### PR DESCRIPTION
Moving cursor around (the "activewindow" event) causes heavy spikes in CPU usage. This is because it calls update_app_map every time which is expensive.
As far as I can tell, update_dock doesn't need to be called on those events, so just don't do it.

At first I suspected that this function is connected to those event because of the workspace overview feature. But testing the overview with and without this PR doesn't change how the overview works.

This PR lowers CPU spikes when moving mouse across windows from 20% to 4% on my system.