### PR TITLE
Fix brightness slider not applying on scroll

### DIFF
--- a/modules/controls.py
+++ b/modules/controls.py
@@ -127,7 +127,6 @@ class BrightnessSlider(Scale):
         self._debounce_timeout = 100
 
         self.connect("change-value", self.on_scale_move)
-        self.connect("scroll-event", self.on_scroll)
         self.client.connect("screen", self.on_brightness_changed)
 
     def on_scale_move(self, widget, scroll, moved_pos):
@@ -150,26 +149,6 @@ class BrightnessSlider(Scale):
         else:
             self._update_source_id = None
             return False
-
-    def on_scroll(self, widget, event):
-        current_value = self.get_value()
-        step_size = 1
-        if event.direction == Gdk.ScrollDirection.SMOOTH:
-            if event.delta_y < 0:
-                new_value = min(current_value + step_size, self.client.max_screen)
-            elif event.delta_y > 0:
-                new_value = max(current_value - step_size, 0)
-            else:
-                return False
-        else:
-            if event.direction == Gdk.ScrollDirection.UP:
-                new_value = min(current_value + step_size, self.client.max_screen)
-            elif event.direction == Gdk.ScrollDirection.DOWN:
-                new_value = max(current_value - step_size, 0)
-            else:
-                return False
-        self.set_value(new_value)
-        return True
 
     def on_brightness_changed(self, client, _):
         self._updating_from_brightness = True


### PR DESCRIPTION
I'm using #211 and noticed that scroll doesn't change the brightness. It's changing the value on the slider but the values doesn't get applied to the monitor.

Turns out the "scroll-event" is not needed at all, just like with mic and volume sliders. There seems to be some race condition with the other events as going step by step with a debugger makes the brightness apply.

Step size can be changed using "increments" on slider's init if need be. First value controls the step with page up/down, the 2nd one controls the scroll step. There is a small bug where you need to press the slider with a mouse first to be able to use page up/down tho.