### PR TITLE
fix: resolve race condition in caffeine toggle notification

### DIFF
--- a/modules/buttons.py
+++ b/modules/buttons.py
@@ -406,15 +406,15 @@ class CaffeineButton(Button):
             exec_shell_command_async("pkill ax-inhibit")
             GLib.idle_add(self.caffeine_status.set_label, "Disabled")
             GLib.idle_add(self._add_disabled_style)
+            new_state = "Disabled"
         except subprocess.CalledProcessError:
             exec_shell_command_async(f"python {data.HOME_DIR}/.config/{data.APP_NAME_CAP}/scripts/inhibit.py")
             GLib.idle_add(self.caffeine_status.set_label, "Enabled")
             GLib.idle_add(self._remove_disabled_style)
+            new_state = "Enabled"
 
         if external:
-            # Different if enabled or disabled
-            status = "Disabled" if self.caffeine_status.get_label() == "Disabled" else "Enabled"
-            message = "Disabled 💤" if status == "Disabled" else "Enabled ☀️"
+            message = "Disabled 💤" if new_state == "Disabled" else "Enabled ☀️"
             exec_shell_command_async(f"notify-send '☕ Caffeine' '{message}' -a '{data.APP_NAME_CAP}' -e")
     
     def _add_disabled_style(self):


### PR DESCRIPTION
## Summary
Fixes a race condition in the caffeine toggle notification that caused it to display the wrong state.

## Problem
When toggling caffeine via external trigger (e.g., keybind), the notification would sometimes show the opposite state:
- Enabling caffeine → notification said "Disabled"
- Disabling caffeine → notification said "Enabled"

## Cause
The code was reading the label via `self.caffeine_status.get_label()` after `GLib.idle_add()` scheduled the label update, but before the GTK main loop executed it. This race condition meant the old label value was read.

## Solution
Track `new_state` directly in the code path instead of reading the label asynchronously:

```python
# Before (race condition):
status = "Disabled" if self.caffeine_status.get_label() == "Disabled" else "Enabled"

# After (tracks state directly):
new_state = "Disabled"  # set in the same code block as the action
message = "Disabled 💤" if new_state == "Disabled" else "Enabled ☀️"
```

## Testing
Tested on Arch Linux with Hyprland. Notification now correctly reflects the caffeine state after toggling.